### PR TITLE
Fix broken cleanUp method in ECCodesLib Class.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class EcCodesLib {
 
   async cleanup() {
     if (this.definitionsPath === null) return
-    await fs.remove(dir)
+    await fs.remove(this.definitionsPath)
     this.definitionsPath = null
   }
 


### PR DESCRIPTION
The cleanUp method in index.js was referring to an undeclared variable `dir`, causing (unhandled) errors.
Replacing with `this.definitionsPath` removes the temporary directory as intended.